### PR TITLE
use node 16

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm run build
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated Node.js version from 14 to 16 in the GitHub Actions workflow. This change enhances the build and deployment environment, potentially improving performance and compatibility with newer packages or features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->